### PR TITLE
Add test grpc interfaces, and add more tests

### DIFF
--- a/proto/ministore.proto
+++ b/proto/ministore.proto
@@ -4,25 +4,58 @@ package ministore;
 
 service MiniService {
     rpc Status(StatusRequest) returns (StatusResponse) {};
+
+    // Test interfaces
     rpc CreateFakeDevice(CreateFakeDeviceRequest) returns (CreateFakeDeviceResponse) {};
+    rpc DeleteFakeDevice(DeleteFakeDeviceRequest) returns (DeleteFakeDeviceResponse) {};
+    rpc ListFakeDevices(ListFakeDevicesRequest) returns (ListFakeDevicesResponse) {};
 }
 
-message StatusRequest {};
+message StatusRequest {}
 message StatusResponse {
     Status status = 1;
-};
+}
 
 enum Status {
     NotReady = 0;
     Ready = 1;
 }
 
+enum FakeDeviceType {
+    SimpleFakeDevice = 0;
+    IoUringFakeDevice = 1;
+}
+
 message CreateFakeDeviceRequest {
     string name = 1;
     uint64 size = 2;
+    FakeDeviceType device_type = 3;
 };
 
 message CreateFakeDeviceResponse {
     bool success = 1;
     optional string reason = 2;
 };
+
+message DeleteFakeDeviceRequest {
+    string name = 1;
+}
+
+message DeleteFakeDeviceResponse {
+    bool success = 1;
+    optional string reason = 2;
+}
+
+message FakeDevice {
+    string name = 1;
+    uint64 size = 2;
+    FakeDeviceType device_type = 3;
+}
+
+message ListFakeDevicesRequest {}
+
+message ListFakeDevicesResponse {
+    bool success = 1;
+    optional string reason = 2;
+    repeated FakeDevice device_list = 3;
+}

--- a/src/block_device/data_type.rs
+++ b/src/block_device/data_type.rs
@@ -1,13 +1,19 @@
 use serde::{Deserialize, Serialize};
 
 pub const BLOCK_SIZE: usize = 4096;
-pub const UNMAP_BLOCK: DataBlock = DataBlock([0xF; BLOCK_SIZE]);
+pub const UNMAP_BLOCK: DataBlock = DataBlock([0xFF; BLOCK_SIZE]);
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, PartialEq)]
 pub struct DataBlock(pub [u8; BLOCK_SIZE]);
 
+impl std::fmt::Debug for DataBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("DataBlock").field(&self.0[0]).finish()
+    }
+}
+
 /// Below is the Serialize / Deserialize implementation for DataBlock
-/// You may need this if you want to serialize or deserialize DataBlock 
+/// You may need this if you want to serialize or deserialize DataBlock
 impl Serialize for DataBlock {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/src/block_device/device_info.rs
+++ b/src/block_device/device_info.rs
@@ -1,20 +1,26 @@
-use super::data_type::BLOCK_SIZE;
+use super::{data_type::BLOCK_SIZE, BlockDeviceType};
 
 #[derive(Clone, Debug)]
 pub struct DeviceInfo {
+    device_type: BlockDeviceType,
     device_name: String,
     device_size: u64,
     num_blocks: u64,
 }
 
 impl DeviceInfo {
-    pub fn new(device_name: String, device_size: u64) -> Result<Self, String> {
+    pub fn new(
+        device_type: BlockDeviceType,
+        device_name: String,
+        device_size: u64,
+    ) -> Result<Self, String> {
         match device_size % BLOCK_SIZE as u64 != 0 {
             true => return Err("Unaligned device size".to_string()),
             false => (),
         }
 
         Ok(Self {
+            device_type,
             device_name,
             device_size,
             num_blocks: device_size / BLOCK_SIZE as u64,
@@ -32,6 +38,10 @@ impl DeviceInfo {
     pub fn num_blocks(&self) -> u64 {
         self.num_blocks
     }
+
+    pub fn device_type(&self) -> BlockDeviceType {
+        self.device_type.clone()
+    }
 }
 
 #[cfg(test)]
@@ -45,7 +55,11 @@ mod test {
         let num_blocks = 100;
         let device_size = block_size * num_blocks;
 
-        let device_info = DeviceInfo::new(device_name.to_string(), device_size);
+        let device_info = DeviceInfo::new(
+            BlockDeviceType::SimpleFakeDevice,
+            device_name.to_string(),
+            device_size,
+        );
         assert_eq!(device_info.is_ok(), true);
 
         assert_eq!(
@@ -57,6 +71,10 @@ mod test {
             device_info.as_ref().unwrap().num_blocks(),
             device_size / block_size
         );
+        assert_eq!(
+            device_info.as_ref().unwrap().device_type(),
+            BlockDeviceType::SimpleFakeDevice
+        );
     }
 
     #[test]
@@ -64,7 +82,11 @@ mod test {
         let device_name = "create_device_info";
         let device_size = 500000;
 
-        let device_info = DeviceInfo::new(device_name.to_string(), device_size);
+        let device_info = DeviceInfo::new(
+            BlockDeviceType::SimpleFakeDevice,
+            device_name.to_string(),
+            device_size,
+        );
 
         assert_eq!(device_info.is_err(), true);
     }

--- a/src/block_device/io_uring_fake_device.rs
+++ b/src/block_device/io_uring_fake_device.rs
@@ -1,3 +1,4 @@
+use super::BlockDeviceType;
 use super::{data_type::DataBlock, device_info::DeviceInfo, BlockDevice};
 use crate::block_device::data_type::{BLOCK_SIZE, UNMAP_BLOCK};
 use std::io::{Seek, Write};
@@ -14,7 +15,7 @@ pub struct IoUringFakeDevice {
 #[cfg(target_os = "linux")]
 impl IoUringFakeDevice {
     pub fn new(name: String, size: u64) -> Result<Self, String> {
-        let device_info = DeviceInfo::new(name, size)?;
+        let device_info = DeviceInfo::new(BlockDeviceType::IoUringFakeDevice, name, size)?;
         let ring = io_uring::IoUring::new(URING_SIZE).map_err(|e| e.to_string())?;
 
         let filename = device_info.name();

--- a/src/device_manager.rs
+++ b/src/device_manager.rs
@@ -1,0 +1,112 @@
+use std::collections::HashMap;
+
+use crate::block_device::{create_block_device, i32_to_block_device_type, BlockDevice};
+
+#[derive(Default)]
+pub struct DeviceManager {
+    devices: HashMap<String, Box<dyn BlockDevice>>,
+}
+
+impl DeviceManager {
+    pub fn create_fake_device(
+        &mut self,
+        device_type: i32,
+        device_name: &String,
+        device_size: u64,
+    ) -> Result<(), String> {
+        if self.devices.contains_key(device_name) {
+            return Err(format!("Device already exists, name:{}", device_name));
+        }
+
+        let device_type = i32_to_block_device_type(device_type)?;
+        let device = create_block_device(device_type, device_name.clone(), device_size)?;
+
+        self.devices.insert(device_name.clone(), device);
+
+        Ok(())
+    }
+
+    pub fn delete_fake_device(&mut self, device_name: &String) -> Result<(), String> {
+        match self.devices.remove(device_name) {
+            Some(device) => {
+                let device_name = device.info().name();
+                std::fs::remove_file(&device_name).map_err(|e| e.to_string())?;
+            }
+            None => return Err(format!("No such device, name:{}", device_name)),
+        };
+
+        Ok(())
+    }
+
+    pub fn list_fake_devices(&self) -> Result<Vec<(String, u64, i32)>, String> {
+        Ok(self
+            .devices
+            .iter()
+            .map(|dev| {
+                (
+                    dev.0.clone(),
+                    dev.1.info().device_size(),
+                    dev.1.info().device_type().into(),
+                )
+            })
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::utils::humansize_to_integer;
+
+    use super::*;
+
+    #[test]
+    fn device_manager_can_create_and_delete_device() {
+        let mut device_manager = DeviceManager::default();
+
+        // type = SimpleFakeDevice
+        // name = "device_manager_can_create_and_delete_device"
+        // size = 1MB
+        let device_name = "device_manager_can_create_and_delete_device".to_string();
+
+        device_manager
+            .create_fake_device(0, &device_name, humansize_to_integer("1M").unwrap())
+            .expect("Failed to create fake device");
+
+        let devices = device_manager
+            .list_fake_devices()
+            .expect("Failed to get device list");
+        assert_eq!(devices.len(), 1);
+        assert_eq!(devices.get(0).unwrap().0, device_name);
+        assert_eq!(
+            devices.get(0).unwrap().1,
+            humansize_to_integer("1M").unwrap()
+        );
+        assert_eq!(devices.get(0).unwrap().2, 0);
+
+        device_manager
+            .delete_fake_device(&device_name)
+            .expect("Failed to remove fake device");
+    }
+
+    #[test]
+    fn device_manager_cannot_create_device_with_same_name_twice() {
+        let mut device_manager = DeviceManager::default();
+
+        // type = SimpleFakeDevice
+        // name = "device_manager_cannot_create_device_with_same_name_twice"
+        // size = 1MB
+        let device_name = "device_manager_cannot_create_device_with_same_name_twice".to_string();
+        device_manager
+            .create_fake_device(0, &device_name, humansize_to_integer("1M").unwrap())
+            .expect("Failed to create fake device");
+
+        assert_eq!(
+            device_manager
+                .create_fake_device(0, &device_name, humansize_to_integer("1M").unwrap())
+                .is_ok(),
+            false
+        );
+
+        std::fs::remove_file(device_name.clone()).expect("Failed to remove file");
+    }
+}

--- a/src/grpc_server/mod.rs
+++ b/src/grpc_server/mod.rs
@@ -1,10 +1,15 @@
 use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
 use tonic::transport::Server;
 use tonic::Response;
 
+use crate::device_manager::DeviceManager;
+
 use self::ministore_proto::mini_service_server::{MiniService, MiniServiceServer};
 use self::ministore_proto::{
-    CreateFakeDeviceRequest, CreateFakeDeviceResponse, Status, StatusRequest, StatusResponse,
+    CreateFakeDeviceRequest, CreateFakeDeviceResponse, DeleteFakeDeviceRequest,
+    DeleteFakeDeviceResponse, FakeDevice, ListFakeDevicesRequest, ListFakeDevicesResponse, Status,
+    StatusRequest, StatusResponse,
 };
 
 pub mod ministore_proto {
@@ -22,7 +27,9 @@ pub async fn start_grpc_server(addr: SocketAddr) -> Result<(), String> {
 }
 
 #[derive(Default)]
-pub struct GrpcServer {}
+pub struct GrpcServer {
+    device_manager: Arc<Mutex<DeviceManager>>,
+}
 
 #[tonic::async_trait]
 impl MiniService for GrpcServer {
@@ -41,11 +48,75 @@ impl MiniService for GrpcServer {
         &self,
         request: tonic::Request<CreateFakeDeviceRequest>,
     ) -> Result<tonic::Response<CreateFakeDeviceResponse>, tonic::Status> {
+        let request = request.into_inner();
+
+        let reply = match self.device_manager.lock().unwrap().create_fake_device(
+            request.device_type,
+            &request.name,
+            request.size,
+        ) {
+            Ok(()) => CreateFakeDeviceResponse {
+                success: true,
+                reason: None,
+            },
+            Err(e) => CreateFakeDeviceResponse {
+                success: false,
+                reason: Some(e),
+            },
+        };
+
+        Ok(Response::new(reply))
+    }
+
+    async fn delete_fake_device(
+        &self,
+        request: tonic::Request<DeleteFakeDeviceRequest>,
+    ) -> Result<tonic::Response<DeleteFakeDeviceResponse>, tonic::Status> {
+        let request = request.into_inner();
+
+        let reply = match self
+            .device_manager
+            .lock()
+            .unwrap()
+            .delete_fake_device(&request.name)
+        {
+            Ok(()) => DeleteFakeDeviceResponse {
+                success: true,
+                reason: None,
+            },
+            Err(e) => DeleteFakeDeviceResponse {
+                success: false,
+                reason: Some(e),
+            },
+        };
+
+        Ok(Response::new(reply))
+    }
+
+    async fn list_fake_devices(
+        &self,
+        request: tonic::Request<ListFakeDevicesRequest>,
+    ) -> Result<tonic::Response<ListFakeDevicesResponse>, tonic::Status> {
         let _request = request.into_inner();
 
-        let reply = CreateFakeDeviceResponse {
-            success: true,
-            reason: None,
+        let reply = match self.device_manager.lock().unwrap().list_fake_devices() {
+            Ok(list) => ListFakeDevicesResponse {
+                success: true,
+                reason: None,
+                device_list: list
+                    .iter()
+                    .map(|dev| FakeDevice {
+                        name: dev.0.clone(),
+                        size: dev.1,
+                        device_type: dev.2,
+                    })
+                    .collect(),
+            },
+            Err(e) => ListFakeDevicesResponse {
+                success: false,
+                reason: Some(e),
+                device_list: Vec::new(),
+            },
         };
 
         Ok(Response::new(reply))
@@ -54,7 +125,10 @@ impl MiniService for GrpcServer {
 
 #[cfg(test)]
 mod tests {
-    use crate::grpc_server::ministore_proto::mini_service_client::MiniServiceClient;
+    use crate::{
+        grpc_server::ministore_proto::mini_service_client::MiniServiceClient,
+        utils::humansize_to_integer,
+    };
 
     use super::*;
 
@@ -81,6 +155,76 @@ mod tests {
                 .await
                 .expect("Failed to get response");
             assert_eq!(response.into_inner().status, Status::Ready as i32);
+        });
+    }
+
+    #[tokio::test]
+    async fn server_can_create_and_delete_fake_device() {
+        let addr = "127.0.0.1:8081";
+        let addr_for_server = addr.parse().expect("Failed to parse socket addr");
+        let addr_for_client = format!("http://{}", addr.clone());
+
+        tokio::spawn(async move {
+            start_grpc_server(addr_for_server)
+                .await
+                .expect("Failed to start grpc server");
+        });
+
+        tokio::spawn(async move {
+            let mut client = MiniServiceClient::connect(addr_for_client)
+                .await
+                .expect("Failed to start test client");
+
+            // Create device and verify it using list devices
+            let device_name = "server_can_create_and_delete_fake_device".to_string();
+            let request = tonic::Request::new(CreateFakeDeviceRequest {
+                name: device_name.clone(),
+                size: humansize_to_integer("1M").unwrap(),
+                device_type: 0, // SimpleFakeDevice
+            });
+            let response = client
+                .create_fake_device(request)
+                .await
+                .expect("Failed to create fake device");
+            let response = response.into_inner();
+            assert_eq!(response.success, true);
+
+            let request = tonic::Request::new(ListFakeDevicesRequest {});
+            let response = client
+                .list_fake_devices(request)
+                .await
+                .expect("Failed to get response");
+            let response = response.into_inner();
+
+            assert_eq!(response.success, true);
+            assert_eq!(response.device_list.len(), 1);
+            assert_eq!(response.device_list.get(0).unwrap().name, device_name);
+            assert_eq!(
+                response.device_list.get(0).unwrap().size,
+                humansize_to_integer("1M").unwrap()
+            );
+            assert_eq!(response.device_list.get(0).unwrap().device_type, 0);
+
+            // Delete device and verify it using list devices
+            let request = tonic::Request::new(DeleteFakeDeviceRequest {
+                name: device_name.clone(),
+            });
+            let response = client
+                .delete_fake_device(request)
+                .await
+                .expect("Failed to delete fake device");
+            let response = response.into_inner();
+            assert_eq!(response.success, true);
+
+            let request = tonic::Request::new(ListFakeDevicesRequest {});
+            let response = client
+                .list_fake_devices(request)
+                .await
+                .expect("Failed to get response");
+            let response = response.into_inner();
+
+            assert_eq!(response.success, true);
+            assert_eq!(response.device_list.len(), 0);
         });
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod block_device;
 pub mod config;
+pub mod device_manager;
 pub mod grpc_server;
 pub mod utils;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-pub fn humansize_to_integer(size_str: &String) -> Result<u64, String> {
+pub fn humansize_to_integer(size_str: &str) -> Result<u64, String> {
     let size_int = size_str
         .trim_end_matches(char::is_alphabetic)
         .parse::<u64>()
@@ -22,11 +22,23 @@ mod tests {
         assert_eq!(humansize_to_integer(&"20k".to_string()).unwrap(), 20 * 1024);
         assert_eq!(humansize_to_integer(&"20K".to_string()).unwrap(), 20 * 1024);
 
-        assert_eq!(humansize_to_integer(&"10m".to_string()).unwrap(), 10 * 1024 * 1024);
-        assert_eq!(humansize_to_integer(&"10M".to_string()).unwrap(), 10 * 1024 * 1024);
+        assert_eq!(
+            humansize_to_integer(&"10m".to_string()).unwrap(),
+            10 * 1024 * 1024
+        );
+        assert_eq!(
+            humansize_to_integer(&"10M".to_string()).unwrap(),
+            10 * 1024 * 1024
+        );
 
-        assert_eq!(humansize_to_integer(&"6g".to_string()).unwrap(), 6 * 1024 * 1024 * 1024);
-        assert_eq!(humansize_to_integer(&"6G".to_string()).unwrap(), 6 * 1024 * 1024 * 1024);
+        assert_eq!(
+            humansize_to_integer(&"6g".to_string()).unwrap(),
+            6 * 1024 * 1024 * 1024
+        );
+        assert_eq!(
+            humansize_to_integer(&"6G".to_string()).unwrap(),
+            6 * 1024 * 1024 * 1024
+        );
 
         assert_eq!(humansize_to_integer(&"100000".to_string()).unwrap(), 100000);
     }


### PR DESCRIPTION
Test gRPC 들을 추가하고, 여기서 테스트하기 쉽게 기존 block device 구현/인터페이스들을 조금씩 수정해 봤습니다.

근데 이런 식의 변경이 계속 일어나면, full set (`hj-main`)과 test 만 남긴 버전 (`main`) 의 싱크 맞추기가 쉽지 않을 것 같아요. 일단 개인적으로는 `hj-main`을 써서 작업하고 정리될 때 마다 손머지를 해 보겠습니다..

* 리뷰어에 안 계신 분들은 collaborator에 안 계셔서인데.. 초대 수락해 주세요 ㅎㅎ
* 앞으로 두 가지의 PR을 올릴 것 같습니다. 참고하셔서 원하시는 PR만 보셔도 될 것 같아요 ㅎ! 일단 이번 건 `hj-main` 용입니다.
   - target repo가 `hj-main` 인 경우: 제 구현 + 테스트 추가/변경 버전
   - target repo가 `main`인 경우: 테스트 추가/변경만. 교육과정용 정제된 버전 (이걸 브랜치 리셋해서 지금 이거 기준으로 새로 만들까봐요....)