### PR TITLE
Fake device to store its metadata and load it when requested

### DIFF
--- a/src/async_block_device/async_simple_fake_device.rs
+++ b/src/async_block_device/async_simple_fake_device.rs
@@ -21,6 +21,7 @@ impl Data {
     }
 }
 
+#[derive(Serialize, Deserialize)]
 pub struct AsyncSimpleFakeDevice {
     device_info: DeviceInfo,
     data: Data,
@@ -116,9 +117,11 @@ impl AsyncSimpleFakeDevice {
         }
 
         let data = tokio::fs::read(path).await.map_err(|e| e.to_string())?;
-        let data = bincode::deserialize_from(data.as_slice()).map_err(|e| e.to_string())?;
+        let loaded_data: AsyncSimpleFakeDevice =
+            bincode::deserialize_from(data.as_slice()).map_err(|e| e.to_string())?;
 
-        self.data = data;
+        self.device_info = loaded_data.device_info;
+        self.data = loaded_data.data;
 
         Ok(())
     }
@@ -134,7 +137,7 @@ impl AsyncSimpleFakeDevice {
             .await
             .map_err(|e| e.to_string())?;
 
-        let data = bincode::serialize(&self.data).map_err(|e| e.to_string())?;
+        let data = bincode::serialize(&self).map_err(|e| e.to_string())?;
         file.write_all(data.as_slice())
             .await
             .map_err(|e| e.to_string())?;
@@ -386,5 +389,40 @@ mod tests {
         tokio::fs::remove_file(device_name)
             .await
             .expect("Failed to remove file");
+    }
+
+    #[tokio::test]
+    async fn async_device_should_be_able_to_provide_device_info_after_load() {
+        let device_name =
+            "async_device_should_be_able_to_provide_device_info_after_load".to_string();
+
+        {
+            let mut device = AsyncSimpleFakeDevice::new(
+                BlockDeviceType::AsyncSimpleFakeDevice,
+                device_name.clone(),
+                BLOCK_SIZE as u64 * 1024,
+            )
+            .await
+            .expect("Failed to create block device");
+
+            device.flush().await.expect("Failed to flush data");
+        }
+
+        {
+            let mut device = AsyncSimpleFakeDevice::new(
+                BlockDeviceType::AsyncSimpleFakeDevice,
+                device_name.clone(),
+                0,
+            )
+            .await
+            .expect("Failed to load a device");
+
+            device.load().await.expect("Failed to load data");
+
+            assert_eq!(device.info().name(), &device_name);
+            assert_eq!(device.info().device_size(), BLOCK_SIZE as u64 * 1024);
+        }
+
+        std::fs::remove_file(&device_name).expect("Failed to remove test file");
     }
 }

--- a/src/block_device/mod.rs
+++ b/src/block_device/mod.rs
@@ -296,4 +296,33 @@ mod tests {
             std::fs::remove_file(&device_name).expect("Failed to remove test file");
         });
     }
+
+    #[test]
+    fn device_should_be_able_to_provide_device_info_after_load() {
+        for_each_block_device_type(|device_type| {
+            let device_name = "device_should_be_able_to_provide_device_info_after_load".to_string();
+
+            {
+                let mut device = create_block_device(
+                    device_type.clone(),
+                    device_name.clone(),
+                    BLOCK_SIZE as u64 * 1024,
+                )
+                .expect("Failed to create block device");
+
+                device.flush().expect("Failed to flush data");
+            }
+
+            {
+                let mut device = create_block_device(device_type.clone(), device_name.clone(), 0)
+                    .expect("Failed to load a device");
+                device.load().expect("Failed to load data");
+
+                assert_eq!(device.info().name(), &device_name);
+                assert_eq!(device.info().device_size(), BLOCK_SIZE as u64 * 1024);
+            }
+
+            std::fs::remove_file(&device_name).expect("Failed to remove test file");
+        });
+    }
 }

--- a/src/block_device/simple_fake_device.rs
+++ b/src/block_device/simple_fake_device.rs
@@ -1,6 +1,6 @@
+use super::{BlockDevice, BlockDeviceType};
 use crate::block_device_common::data_type::{DataBlock, UNMAP_BLOCK};
 use crate::block_device_common::device_info::DeviceInfo;
-use super::{BlockDeviceType, BlockDevice};
 
 use serde::{Deserialize, Serialize};
 use std::{fs::OpenOptions, path::Path};
@@ -18,6 +18,7 @@ impl Data {
     }
 }
 
+#[derive(Serialize, Deserialize)]
 pub struct SimpleFakeDevice {
     device_info: DeviceInfo,
     data: Data,
@@ -106,8 +107,11 @@ impl BlockDevice for SimpleFakeDevice {
             .open(&path)
             .map_err(|e| e.to_string())?;
 
-        let loaded_data = bincode::deserialize_from(&mut file).map_err(|e| e.to_string())?;
-        self.data = loaded_data;
+        let loaded_data: SimpleFakeDevice =
+            bincode::deserialize_from(&mut file).map_err(|e| e.to_string())?;
+
+        self.device_info = loaded_data.device_info;
+        self.data = loaded_data.data;
 
         Ok(())
     }
@@ -124,7 +128,7 @@ impl BlockDevice for SimpleFakeDevice {
             .open(&path)
             .map_err(|e| e.to_string())?;
 
-        bincode::serialize_into(&mut file, &self.data).map_err(|e| e.to_string())?;
+        bincode::serialize_into(&mut file, &self).map_err(|e| e.to_string())?;
 
         Ok(())
     }

--- a/src/block_device_common/device_info.rs
+++ b/src/block_device_common/device_info.rs
@@ -1,7 +1,8 @@
 use super::data_type::BLOCK_SIZE;
 use super::BlockDeviceType;
+use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DeviceInfo {
     device_type: BlockDeviceType,
     device_name: String,

--- a/src/block_device_common/mod.rs
+++ b/src/block_device_common/mod.rs
@@ -1,9 +1,10 @@
 pub mod data_type;
 pub mod device_info;
 
+use serde::{Deserialize, Serialize};
 use strum_macros::{Display, EnumIter};
 
-#[derive(Debug, EnumIter, Clone, Display, PartialEq)]
+#[derive(Debug, EnumIter, Clone, Display, PartialEq, Serialize, Deserialize)]
 pub enum BlockDeviceType {
     SimpleFakeDevice,
     IoUringFakeDevice,


### PR DESCRIPTION
Fake device 파일만 있으면 device info를 알 수 있는 것이 실제 디바이스 동작과 더 가까운 것 같고, 이후 있을 개발/테스트에서도 유용할 것 같아 기능 및 테스트 추가하였습니다.